### PR TITLE
Use new QR field when retrieving WhatsApp QR code

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -1067,9 +1067,9 @@ const AgentManager = {
 
       const data = await response.json();
       
-      // O backend retorna { qr_code: "base64_string", status: "...", expires_at: "..." }
-      if (data.qr_code) {
-        return data.qr_code;
+      // O backend retorna { qr: "base64_string", status: "...", expires_at: "..." }
+      if (data.qr) {
+        return data.qr;
       } else {
         throw new Error('QR Code não disponível');
       }


### PR DESCRIPTION
## Summary
- Update frontend QR retrieval to use `data.qr` instead of `data.qr_code`

## Testing
- `pytest -q` *(fails: SyntaxError in backend/websocket/websocket_handlers.py)*

------
https://chatgpt.com/codex/tasks/task_e_68ac6a5c16988322bafc117d333c64f0