### PR TITLE
feat: add webhook configuration endpoint

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -495,6 +495,45 @@ async def get_instance_status(
             detail=f"Erro ao consultar status: {str(e)}"
         )
 
+@app.post("/api/wpp/instances/{instance_id}/webhook")
+async def set_instance_webhook(
+    instance_id: str,
+    payload: Dict[str, Any],
+    evolution_service: EvolutionService = Depends(get_evolution_service)
+):
+    """Configura webhook para uma instância específica"""
+
+    logger.info(f"🔗 Configurando webhook para {instance_id}")
+
+    try:
+        webhook_url = payload.get("webhook_url")
+        events = payload.get("events")
+
+        if not webhook_url:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="webhook_url é obrigatório"
+            )
+
+        success = await evolution_service.set_webhook(instance_id, webhook_url, events)
+
+        if success:
+            return {"status": "success", "message": "Webhook configurado com sucesso"}
+
+        return JSONResponse(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            content={"status": "error", "message": "Falha ao configurar webhook"}
+        )
+
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"❌ Erro ao configurar webhook {instance_id}: {str(e)}")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Erro ao configurar webhook: {str(e)}"
+        )
+
 @app.post("/api/wpp/messages")
 async def send_test_message(
     message_data: SendMessage,

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -1170,15 +1170,19 @@ const AgentManager = {
           events: ['messages.upsert', 'connection.update']
         })
       });
+      const data = await response.json().catch(() => ({}));
 
-      if (response.ok) {
+      if (response.ok && data.status === 'success') {
         Logger.log('info', 'whatsapp', `Webhook configurado: ${webhookUrl}`);
-        Toast.success('WhatsApp', 'Webhook configurado com sucesso!');
+        Toast.success('WhatsApp', data.message || 'Webhook configurado com sucesso!');
       } else {
-        Logger.log('warning', 'whatsapp', 'Falha ao configurar webhook');
+        const errorMessage = data.message || 'Falha ao configurar webhook';
+        Logger.log('warning', 'whatsapp', errorMessage);
+        Toast.error('WhatsApp', errorMessage);
       }
     } catch (error) {
       Logger.log('error', 'whatsapp', `Erro ao configurar webhook: ${error.message}`);
+      Toast.error('WhatsApp', `Erro ao configurar webhook: ${error.message}`);
     }
   },
 


### PR DESCRIPTION
## Summary
- add backend route to configure webhooks for WhatsApp instances
- handle webhook setup feedback in the frontend

## Testing
- `pytest` *(fails: SyntaxError in backend/websocket/websocket_handlers.py)*

------
https://chatgpt.com/codex/tasks/task_e_68ac6d34ab188322ab8626e483b063a7