### PR TITLE
Add agent repository and CRUD endpoints

### DIFF
--- a/backend/models.py
+++ b/backend/models.py
@@ -131,7 +131,7 @@ class Agent:
         }, sort_keys=True)
         
         return hashlib.md5(config_str.encode()).hexdigest()
-    
+
     def to_dict(self) -> Dict[str, Any]:
         """Converte para dicionário"""
         return {
@@ -148,6 +148,84 @@ class Agent:
             'error_count': self.error_count,
             'config': self.config
         }
+
+
+class AgentRepository:
+    """Repositório simples para gerenciamento de agentes.
+
+    Os dados são mantidos em memória e persistidos em disco em formato JSON.
+    """
+
+    def __init__(self, storage_path: Union[str, Path]):
+        self.storage_path = Path(storage_path)
+        self._agents: Dict[str, Agent] = {}
+
+    # -----------------------------------------------------
+    # Operações de persistência
+    # -----------------------------------------------------
+    def load(self) -> None:
+        """Carrega agentes do arquivo JSON se existir."""
+        if self.storage_path.exists():
+            data = json.loads(self.storage_path.read_text(encoding="utf-8"))
+            self._agents = {item["id"]: Agent(**item) for item in data}
+
+    def save(self) -> None:
+        """Salva agentes atuais no arquivo JSON."""
+        data = [agent.to_dict() for agent in self._agents.values()]
+        self.storage_path.write_text(
+            json.dumps(data, indent=2, ensure_ascii=False), encoding="utf-8"
+        )
+
+    # -----------------------------------------------------
+    # Métodos CRUD
+    # -----------------------------------------------------
+    def list_agents(self) -> List[Agent]:
+        """Retorna todos os agentes."""
+        return list(self._agents.values())
+
+    def get_agent(self, agent_id: str) -> Optional[Agent]:
+        """Obtém agente pelo ID."""
+        return self._agents.get(agent_id)
+
+    def create_agent(self, data: Dict[str, Any]) -> Agent:
+        """Cria novo agente a partir dos dados fornecidos."""
+        agent = Agent(
+            id=data.get("id") or Agent.generate_id(),
+            name=data["name"],
+            specialization=data["specialization"],
+            instructions=data["instructions"],
+            tools=list(data["tools"]),
+        )
+        self._agents[agent.id] = agent
+        self.save()
+        return agent
+
+    def update_agent(self, agent_id: str, data: Dict[str, Any]) -> Optional[Agent]:
+        """Atualiza um agente existente."""
+        agent = self._agents.get(agent_id)
+        if not agent:
+            return None
+
+        if "name" in data:
+            agent.name = data["name"]
+        if "specialization" in data:
+            agent.specialization = data["specialization"]
+        if "instructions" in data:
+            agent.instructions = data["instructions"]
+        if "tools" in data and data["tools"] is not None:
+            agent.tools = list(data["tools"])
+        agent.updated_at = datetime.now()
+        self._agents[agent_id] = agent
+        self.save()
+        return agent
+
+    def delete_agent(self, agent_id: str) -> bool:
+        """Remove um agente pelo ID."""
+        if agent_id in self._agents:
+            del self._agents[agent_id]
+            self.save()
+            return True
+        return False
 
 @dataclass
 class GeneratedFile:


### PR DESCRIPTION
## Summary
- add `AgentRepository` with JSON persistence
- expose REST endpoints for managing agents
- define Pydantic schemas for agent CRUD

## Testing
- `pytest` *(fails: SyntaxError in backend/websocket/websocket_handlers.py)*

------
https://chatgpt.com/codex/tasks/task_e_68ac87e6115083228063d4710115133c