### PR TITLE
Add agent detail view and API integration

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -801,6 +801,13 @@ const ApiClient = {
   },
 
   /**
+   * Obtém dados de um agente específico
+   */
+  async getAgent(agentId) {
+    return this.request(`/api/agents/${agentId}`);
+  },
+
+  /**
    * Atualiza agente existente
    */
   async updateAgent(agentId, agentData) {
@@ -926,6 +933,7 @@ const Navigation = {
 // Gerenciador de Agentes
 const AgentManager = {
   editingAgentId: null,
+  currentAgentId: null,
 
   /**
    * Renderiza lista de agentes
@@ -969,6 +977,9 @@ const AgentManager = {
           </div>
         </div>
         <div class="agent-card-actions">
+          <button type="button" class="button button-small" onclick="AgentManager.viewAgent('${agent.id}')">
+            Detalhes
+          </button>
           <button type="button" class="button button-small" onclick="AgentManager.previewAgent('${agent.id}')">
             Pré-visualizar
           </button>
@@ -1035,6 +1046,38 @@ const AgentManager = {
     };
     
     return badges[status] || badges.DESCONHECIDO;
+  },
+
+  /**
+   * Exibe detalhes do agente
+   */
+  async viewAgent(agentId) {
+    try {
+      const agent = await ApiClient.getAgent(agentId);
+      this.currentAgentId = agentId;
+
+      const nameInput = document.getElementById('detail-agent-name');
+      const instructionsInput = document.getElementById('detail-agent-instructions');
+      const toolsContainer = document.getElementById('detail-agent-tools');
+      const statsContainer = document.getElementById('detail-agent-stats');
+
+      if (nameInput) nameInput.value = agent.name || '';
+      if (instructionsInput) instructionsInput.value = agent.instructions || '';
+      if (toolsContainer) {
+        toolsContainer.innerHTML = (agent.tools || []).map(t => `<span class="tool-tag">${t}</span>`).join('');
+      }
+      if (statsContainer) {
+        statsContainer.innerHTML = `
+          <p>Mensagens processadas: ${agent.messages_processed || 0}</p>
+          <p>Uptime: ${agent.uptime_seconds || 0}s</p>
+          <p>Erros: ${agent.error_count || 0}</p>
+        `;
+      }
+
+      Navigation.switchSection('page-agent-detail');
+    } catch (error) {
+      Toast.error('Erro', error.message || 'Não foi possível carregar o agente');
+    }
   },
 
   /**

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -250,6 +250,61 @@
             </div>
         </section>
 
+        <!-- Seção de Detalhes do Agente -->
+        <section id="page-agent-detail" class="page-section" aria-labelledby="agent-detail-title">
+            <div class="section-container">
+                <div class="section-card">
+                    <header class="card-header">
+                        <div class="card-header-row">
+                            <div>
+                                <h2 id="agent-detail-title" class="card-title">Detalhes do Agente</h2>
+                                <p class="card-description">Informações completas do agente</p>
+                            </div>
+                            <button type="button" class="button button-small" onclick="Navigation.switchSection('page-agents')">
+                                ← Voltar
+                            </button>
+                        </div>
+                    </header>
+
+                    <div class="form-group">
+                        <div class="input-wrapper">
+                            <input type="text" id="detail-agent-name" class="form-input" readonly />
+                            <label for="detail-agent-name" class="form-label">Nome</label>
+                        </div>
+                    </div>
+
+                    <div class="form-group">
+                        <div class="input-wrapper">
+                            <textarea id="detail-agent-instructions" class="form-textarea" rows="5" readonly></textarea>
+                            <label for="detail-agent-instructions" class="form-label">Instruções</label>
+                        </div>
+                    </div>
+
+                    <div class="form-group">
+                        <label class="form-label">Integrações</label>
+                        <div id="detail-agent-tools" class="agent-tools"></div>
+                    </div>
+
+                    <div class="form-group">
+                        <label class="form-label">Estatísticas</label>
+                        <div id="detail-agent-stats" class="agent-stats"></div>
+                    </div>
+
+                    <div class="form-actions">
+                        <button type="button" class="button button-secondary" onclick="AgentManager.editAgent(AgentManager.currentAgentId)">
+                            Editar
+                        </button>
+                        <button type="button" class="button button-accent" onclick="AgentManager.connectWhatsApp(AgentManager.currentAgentId)">
+                            Conectar WhatsApp
+                        </button>
+                        <button type="button" class="button button-danger" onclick="AgentManager.deleteAgent(AgentManager.currentAgentId)">
+                            Excluir
+                        </button>
+                    </div>
+                </div>
+            </div>
+        </section>
+
         <!-- Seção 3: Logs -->
         <section id="page-logs" class="page-section" aria-labelledby="logs-title">
             <div class="section-container">


### PR DESCRIPTION
## Summary
- add page-agent-detail section with read-only fields and action buttons
- implement AgentManager.viewAgent to fetch details from `/api/agents/{id}`
- enable navigation from agent cards to the detail page

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'pydantic_settings'; SyntaxError in backend/websocket/websocket_handlers.py)*

------
https://chatgpt.com/codex/tasks/task_e_68ac8e65d9d883229709d802285027f0