### PR TITLE
feat: enforce token auth for agent management

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,9 +125,19 @@ python -m http.server 5500
 ### 4. Acesso à Aplicação
 
 - **Frontend**: http://localhost:5500
-- **Backend API**: http://localhost:8000  
+- **Backend API**: http://localhost:8000
 - **Documentação**: http://localhost:8000/docs
 - **Health Check**: http://localhost:8000/api/health
+
+---
+
+### 🔑 Token de Acesso
+
+O backend exige autenticação via header `Authorization: Bearer <TOKEN>`.
+
+- Defina o token através da variável de ambiente `API_SECRET`.
+- No frontend, informe o token em **Configurações → Conexões → API Access Token**.
+- Requisições sem token válido retornam `401 Unauthorized`.
 
 ---
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -455,11 +455,11 @@
 
                     <div class="form-group">
                         <div class="input-wrapper">
-                            <input 
-                                type="url" 
-                                id="api-base-url" 
-                                class="form-input" 
-                                value="http://localhost:8000" 
+                            <input
+                                type="url"
+                                id="api-base-url"
+                                class="form-input"
+                                value="http://localhost:8000"
                                 readonly
                             />
                             <label for="api-base-url" class="form-label">API Base URL</label>
@@ -468,6 +468,19 @@
                             <span class="button-icon">🔌</span>
                             <span class="button-text">Testar Conexão</span>
                         </button>
+                    </div>
+
+                    <div class="form-group">
+                        <div class="input-wrapper">
+                            <input
+                                type="password"
+                                id="api-token"
+                                class="form-input"
+                                placeholder="Seu token de acesso"
+                                autocomplete="off"
+                            />
+                            <label for="api-token" class="form-label">API Access Token</label>
+                        </div>
                     </div>
                 </div>
 


### PR DESCRIPTION
## Summary
- require Authorization token for agent CRUD endpoints
- send Bearer token from frontend and redirect unauthenticated users to settings
- document token requirement and add config field in UI

## Testing
- `python -m py_compile backend/main.py`
- `pytest` *(fails: ModuleNotFoundError or syntax error in websocket handlers)*

------
https://chatgpt.com/codex/tasks/task_e_68ac8fe9d0d083229bf2bccaae77e3d1