### PR TITLE
feat: add system event logging

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -1237,6 +1237,7 @@ const AgentManager = {
       Modal.close();
       this.editingAgentId = null;
       Toast.success('Agente atualizado', 'As alterações foram salvas');
+      Logger.log('info', 'frontend', `Agente atualizado: ${updatedAgent.id}`);
     } catch (error) {
       Toast.error('Erro', error.message || 'Não foi possível salvar o agente');
     }
@@ -1535,6 +1536,7 @@ const AgentManager = {
       StateManager.persistState();
       this.renderAgents();
       Toast.success('Excluído', 'Agente removido com sucesso');
+      Logger.log('info', 'frontend', `Agente removido: ${agentId}`);
     } catch (error) {
       Toast.error('Erro', error.message || 'Não foi possível excluir o agente');
     }


### PR DESCRIPTION
## Summary
- add log_event helper to persist SystemEvent records and expose /api/events
- record events after agent create, update and delete operations
- log successful agent updates and deletions on the frontend

## Testing
- `pytest` *(fails: SyntaxError in backend/websocket/websocket_handlers.py)*

------
https://chatgpt.com/codex/tasks/task_e_68ac9522f28883228c3cfef77b9f7bcd