### PR TITLE
feat: add websocket authentication

### DIFF
--- a/backend/websocket/websocket_manager.py
+++ b/backend/websocket/websocket_manager.py
@@ -26,6 +26,7 @@ import uuid
 from fastapi import WebSocket, WebSocketDisconnect, status
 from loguru import logger
 import redis.asyncio as redis
+from starlette.websockets import WebSocketState
 
 from .websocket_events import EventType, WebSocketEvent
 from .websocket_auth import WebSocketAuthenticator
@@ -123,7 +124,8 @@ class ConnectionManager:
     
     async def connect(self, websocket: WebSocket, connection_id: Optional[str] = None) -> WebSocketConnection:
         """Aceita uma nova conexão WebSocket"""
-        await websocket.accept()
+        if websocket.application_state != WebSocketState.CONNECTED:
+            await websocket.accept()
         
         if not connection_id:
             connection_id = str(uuid.uuid4())

--- a/websocket_simple_test.py
+++ b/websocket_simple_test.py
@@ -10,8 +10,9 @@ from datetime import datetime
 import time
 
 class WebSocketTester:
-    def __init__(self, url: str = "ws://localhost:8000/ws"):
+    def __init__(self, url: str = "ws://localhost:8000/ws", token: str = "test-token"):
         self.url = url
+        self.token = token
         
     async def test_connection(self):
         """Test basic connection"""
@@ -23,13 +24,16 @@ class WebSocketTester:
             async with websockets.connect(self.url, ping_interval=20, ping_timeout=10) as websocket:
                 connect_time = time.time() - start_time
                 print(f"Connection established in {connect_time:.3f}s")
-                
+
+                # Send authentication token as first message
+                await websocket.send(self.token)
+
                 test_message = {
                     "type": "ping",
                     "timestamp": datetime.now().isoformat(),
                     "data": {"test": "connection_test"}
                 }
-                
+
                 await websocket.send(json.dumps(test_message))
                 print("Message sent successfully")
                 
@@ -55,6 +59,8 @@ class WebSocketTester:
         
         try:
             async with websockets.connect(self.url) as websocket:
+                # Send authentication token first
+                await websocket.send(self.token)
                 latencies = []
                 
                 for i in range(count):
@@ -118,6 +124,7 @@ async def main():
         
         try:
             async with websockets.connect(url, ping_timeout=3) as ws:
+                await ws.send("test-token")
                 print(f"Found WebSocket server on port {port}")
                 tester = WebSocketTester(url)
                 result = await tester.run_tests()


### PR DESCRIPTION
## Summary
- authenticate websocket connections before delegating to manager
- avoid double-accept in connection manager
- send auth token first in websocket test client

## Testing
- `pytest` *(fails: SyntaxError: unexpected character after line continuation character)*


------
https://chatgpt.com/codex/tasks/task_e_68ac9d6cc2e08322b6f818d5e97e2fd7