### PR TITLE
feat(database): add core tables schema

### DIFF
--- a/database/schema.ts
+++ b/database/schema.ts
@@ -1,0 +1,119 @@
+import { sqliteTable, integer, text, index } from "drizzle-orm/sqlite-core";
+import { sql } from "drizzle-orm";
+
+export const agents = sqliteTable("agents", {
+  id: integer("id").primaryKey({ autoIncrement: true }),
+  name: text("name").notNull(),
+  specialization: text("specialization"),
+  instructions: text("instructions"),
+  status: text("status").notNull().default("inactive"),
+  createdAt: integer("created_at", { mode: "timestamp" })
+    .notNull()
+    .default(sql`CURRENT_TIMESTAMP`),
+  updatedAt: integer("updated_at", { mode: "timestamp" })
+    .notNull()
+    .default(sql`CURRENT_TIMESTAMP`)
+    .$onUpdate(() => sql`CURRENT_TIMESTAMP`),
+});
+
+export const whatsappInstances = sqliteTable(
+  "whatsapp_instances",
+  {
+    id: integer("id").primaryKey({ autoIncrement: true }),
+    agentId: integer("agent_id")
+      .notNull()
+      .references(() => agents.id, { onDelete: "cascade" }),
+    status: text("status").notNull().default("inactive"),
+    qrCode: text("qr_code"),
+    phoneNumber: text("phone_number"),
+    createdAt: integer("created_at", { mode: "timestamp" })
+      .notNull()
+      .default(sql`CURRENT_TIMESTAMP`),
+    updatedAt: integer("updated_at", { mode: "timestamp" })
+      .notNull()
+      .default(sql`CURRENT_TIMESTAMP`)
+      .$onUpdate(() => sql`CURRENT_TIMESTAMP`),
+  },
+  (table) => ({
+    agentIdx: index("idx_whatsapp_instances_agent").on(table.agentId),
+  })
+);
+
+export const messages = sqliteTable(
+  "messages",
+  {
+    id: integer("id").primaryKey({ autoIncrement: true }),
+    instanceId: integer("instance_id")
+      .notNull()
+      .references(() => whatsappInstances.id, { onDelete: "cascade" }),
+    agentId: integer("agent_id")
+      .notNull()
+      .references(() => agents.id, { onDelete: "cascade" }),
+    fromNumber: text("from_number"),
+    toNumber: text("to_number"),
+    content: text("content"),
+    createdAt: integer("created_at", { mode: "timestamp" })
+      .notNull()
+      .default(sql`CURRENT_TIMESTAMP`),
+    updatedAt: integer("updated_at", { mode: "timestamp" })
+      .notNull()
+      .default(sql`CURRENT_TIMESTAMP`)
+      .$onUpdate(() => sql`CURRENT_TIMESTAMP`),
+  },
+  (table) => ({
+    instanceIdx: index("idx_messages_instance").on(table.instanceId),
+    agentIdx: index("idx_messages_agent").on(table.agentId),
+  })
+);
+
+export const conversations = sqliteTable(
+  "conversations",
+  {
+    chatId: text("chat_id").primaryKey(),
+    instanceId: integer("instance_id")
+      .notNull()
+      .references(() => whatsappInstances.id, { onDelete: "cascade" }),
+    agentId: integer("agent_id")
+      .notNull()
+      .references(() => agents.id, { onDelete: "cascade" }),
+    contactNumber: text("contact_number").notNull(),
+    createdAt: integer("created_at", { mode: "timestamp" })
+      .notNull()
+      .default(sql`CURRENT_TIMESTAMP`),
+    updatedAt: integer("updated_at", { mode: "timestamp" })
+      .notNull()
+      .default(sql`CURRENT_TIMESTAMP`)
+      .$onUpdate(() => sql`CURRENT_TIMESTAMP`),
+  },
+  (table) => ({
+    instanceIdx: index("idx_conversations_instance").on(table.instanceId),
+    agentIdx: index("idx_conversations_agent").on(table.agentId),
+  })
+);
+
+export const systemEvents = sqliteTable(
+  "system_events",
+  {
+    id: integer("id").primaryKey({ autoIncrement: true }),
+    eventType: text("event_type").notNull(),
+    source: text("source"),
+    targetId: integer("target_id"),
+    data: text("data"),
+    createdAt: integer("created_at", { mode: "timestamp" })
+      .notNull()
+      .default(sql`CURRENT_TIMESTAMP`),
+    updatedAt: integer("updated_at", { mode: "timestamp" })
+      .notNull()
+      .default(sql`CURRENT_TIMESTAMP`)
+      .$onUpdate(() => sql`CURRENT_TIMESTAMP`),
+  },
+  (table) => ({
+    typeIdx: index("idx_system_events_type").on(table.eventType),
+  })
+);
+
+export type Agent = typeof agents.$inferSelect;
+export type WhatsappInstance = typeof whatsappInstances.$inferSelect;
+export type Message = typeof messages.$inferSelect;
+export type Conversation = typeof conversations.$inferSelect;
+export type SystemEvent = typeof systemEvents.$inferSelect;


### PR DESCRIPTION
## Summary
- add schema definitions for agents, WhatsApp instances, messages, conversations, and system events
- include indexes and foreign key references for relational integrity

## Testing
- `npm test`
- `npm run drizzle` *(fails: No config path provided, drizzle.config.json does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_68aca6b08a64832297241dfaa6f71eed