### PR TITLE
Persist WhatsApp instances and messages

### DIFF
--- a/backend/db/__init__.py
+++ b/backend/db/__init__.py
@@ -1,2 +1,4 @@
 from .agent_repository import AgentRepository
 from .system_event_repository import SystemEventRepository
+from .whatsapp_instance_repository import WhatsAppInstanceRepository
+from .message_repository import MessageRepository

--- a/backend/db/message_repository.py
+++ b/backend/db/message_repository.py
@@ -1,0 +1,19 @@
+"""Repository for persisting WhatsApp messages via Node bridge."""
+
+from typing import Any, Dict, List
+
+from .client import run as run_query
+
+
+class MessageRepository:
+    """Wrapper around Drizzle queries for messages."""
+
+    async def log_message(self, data: Dict[str, Any]) -> Dict[str, Any]:
+        """Insert a new message record."""
+        return await run_query("create_message", data)
+
+    async def list_by_instance(self, instance_id: int) -> List[Dict[str, Any]]:
+        """Return all messages for a given instance."""
+        rows = await run_query("list_messages_by_instance", {"instanceId": instance_id})
+        return rows or []
+

--- a/backend/db/whatsapp_instance_repository.py
+++ b/backend/db/whatsapp_instance_repository.py
@@ -1,0 +1,28 @@
+"""Repository for persisting WhatsApp instances via Node bridge."""
+
+from typing import Any, Dict, List, Optional
+
+from .client import run as run_query
+
+
+class WhatsAppInstanceRepository:
+    """Simple wrapper around Drizzle queries for whatsapp_instances."""
+
+    async def create_instance(self, data: Dict[str, Any]) -> Dict[str, Any]:
+        """Create a new whatsapp instance record."""
+        return await run_query("create_instance", data)
+
+    async def update_instance(self, instance_id: int, data: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+        """Update fields on an instance and return the updated row."""
+        payload = {"id": instance_id, "data": data}
+        return await run_query("update_instance", payload)
+
+    async def get_instance(self, instance_id: int) -> Optional[Dict[str, Any]]:
+        """Fetch a single instance by id."""
+        return await run_query("get_instance", {"id": instance_id})
+
+    async def list_instances(self) -> List[Dict[str, Any]]:
+        """List all stored instances."""
+        rows = await run_query("list_instances")
+        return rows or []
+

--- a/database/bridge.ts
+++ b/database/bridge.ts
@@ -12,6 +12,16 @@ import {
   listSystemEventsByType,
   initSystemEvents,
 } from "./repositories/events";
+import {
+  createInstance,
+  getInstanceById,
+  listInstances,
+  updateInstance,
+} from "./repositories/instances";
+import {
+  createMessage,
+  listMessagesByInstance,
+} from "./repositories/messages";
 
 const [, , action, payloadJson] = process.argv;
 
@@ -53,6 +63,28 @@ async function main() {
     case "init_events":
       await initSystemEvents();
       console.log("null");
+      break;
+    case "create_instance":
+      console.log(JSON.stringify(await createInstance(payload)));
+      break;
+    case "get_instance":
+      console.log(JSON.stringify(await getInstanceById(payload.id)));
+      break;
+    case "list_instances":
+      console.log(JSON.stringify(await listInstances()));
+      break;
+    case "update_instance":
+      console.log(
+        JSON.stringify(await updateInstance(payload.id, payload.data))
+      );
+      break;
+    case "create_message":
+      console.log(JSON.stringify(await createMessage(payload)));
+      break;
+    case "list_messages_by_instance":
+      console.log(
+        JSON.stringify(await listMessagesByInstance(payload.instanceId))
+      );
       break;
     default:
       console.error(`Unknown action: ${action}`);

--- a/database/repositories/instances.ts
+++ b/database/repositories/instances.ts
@@ -22,3 +22,15 @@ export async function getInstanceById(
 export async function listInstances(): Promise<WhatsappInstance[]> {
   return db.select().from(whatsappInstances);
 }
+
+export async function updateInstance(
+  id: number,
+  data: Partial<typeof whatsappInstances.$inferInsert>
+): Promise<WhatsappInstance | undefined> {
+  const [row] = await db
+    .update(whatsappInstances)
+    .set(data)
+    .where(eq(whatsappInstances.id, id))
+    .returning();
+  return row;
+}


### PR DESCRIPTION
## Summary
- add repositories for whatsapp instances and messages
- record qr codes and messages using database repositories
- replace in-memory tracking in EvolutionService with database-backed persistence

## Testing
- `pytest` *(fails: SyntaxError in backend/auth/jwt_auth.py)*

------
https://chatgpt.com/codex/tasks/task_e_68acb3fe2d0c8322835070d73bc93b55