### PR TITLE
Run DB migrations at startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,15 +108,25 @@ uvicorn main:app --reload --port 8000
 
 #### Banco de Dados
 
-Por padrão o projeto usa SQLite. Para migrar para PostgreSQL:
+O backend utiliza o Drizzle para gerenciar migrações. É possível alternar entre
+SQLite e PostgreSQL configurando a variável `DB_PROVIDER` e executando as
+migrações correspondentes:
 
 ```bash
+# SQLite (padrão)
+export DB_PROVIDER=sqlite   # ou remova para usar o padrão
+npm run migrate
+```
+
+```bash
+# PostgreSQL
 export DB_PROVIDER=postgres
 export DATABASE_URL=postgres://usuario:senha@localhost:5432/lux
 npm run migrate
 ```
 
-Retire as variáveis para voltar ao SQLite.
+Para retornar ao SQLite, defina `DB_PROVIDER=sqlite` (e remova `DATABASE_URL`),
+e execute novamente `npm run migrate`.
 
 ### 3. Frontend Setup
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -20,6 +20,7 @@ import sys
 import json
 import asyncio
 import uuid
+import subprocess
 from contextlib import asynccontextmanager
 from typing import List, Dict, Any, Optional
 from pathlib import Path
@@ -176,6 +177,17 @@ async def lifespan(app: FastAPI):
     # Cria diretórios necessários
     settings.generated_agents_dir.mkdir(exist_ok=True)
     logger.info(f"Diretório de agentes criado: {settings.generated_agents_dir}")
+
+    # Executa migrações do banco de dados
+    try:
+        subprocess.run(
+            ["npm", "run", "migrate"],
+            check=True,
+            cwd=Path(__file__).resolve().parent.parent,
+        )
+        logger.info("Migrações executadas")
+    except Exception as e:
+        logger.error(f"Falha ao executar migrações: {e}")
 
     # Inicializa repositórios
     await agent_repo.init()


### PR DESCRIPTION
## Summary
- invoke database migrations during FastAPI startup before repository initialization
- explain how to switch DB_PROVIDER between sqlite and postgres and run migrations

## Testing
- `npm test`
- `npm run migrate` *(fails: drizzle-kit not found)*
- `pytest` *(fails: SyntaxError in backend/auth/jwt_auth.py)*

------
https://chatgpt.com/codex/tasks/task_e_68acb6f771608322a9d048852772308b