### PR TITLE
docs: add development cycle flowchart

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,18 @@ O backend exige autenticação via header `Authorization: Bearer <TOKEN>`.
 - No frontend, informe o token em **Configurações → Conexões → API Access Token**.
 - Requisições sem token válido retornam `401 Unauthorized`.
 
+### Ciclo de Desenvolvimento
+
+```mermaid
+flowchart LR
+  A[Clonar repositório] --> B[Criar ambiente virtual]
+  B --> C[Instalar dependências]
+  C --> D[Configurar .env]
+  D --> E[Executar backend]
+  E --> F[Rodar frontend]
+  F --> G[Testar integrações]
+```
+
 ---
 
 ## 🔐 Configuração de Ambiente


### PR DESCRIPTION
## Summary
- document development cycle with a mermaid flowchart

## Testing
- `npm test`
- `pytest` *(fails: ModuleNotFoundError: No module named 'aiofiles')*

------
https://chatgpt.com/codex/tasks/task_e_68ad76368fc88322b233b7f47a55dfd1