### PR TITLE
Use async DB repos for messages and conversations

### DIFF
--- a/backend/services/evolution.py
+++ b/backend/services/evolution.py
@@ -38,6 +38,7 @@ except ImportError:
 from models import Message, ConnectionState, MessageType
 from backend.db.instance_repo import InstanceRepo
 from backend.db.message_repo import MessageRepo
+from backend.db.conversation_repo import ConversationRepo
 
 class EvolutionAPIError(Exception):
     """Exceção personalizada para erros da Evolution API"""
@@ -69,6 +70,7 @@ class EvolutionService:
         # Repositories
         self.instance_repo = InstanceRepo()
         self.message_repo = MessageRepo()
+        self.conversation_repo = ConversationRepo()
         
         # Callbacks para eventos
         self._message_callbacks: List[Callable] = []
@@ -554,6 +556,18 @@ class EvolutionService:
             
             instance_id = self._instance_ids.get(instance_name)
             if instance_id:
+                chat_id = f"{to}@s.whatsapp.net"
+                existing = await self.conversation_repo.get(chat_id)
+                if not existing:
+                    await self.conversation_repo.create(
+                        {
+                            "chatId": chat_id,
+                            "instanceId": instance_id,
+                            "agentId": 1,
+                            "contactNumber": to,
+                        }
+                    )
+
                 await self.message_repo.create(
                     {
                         "instanceId": instance_id,


### PR DESCRIPTION
## Summary
- wire up new Instance, Message and Conversation repositories in main API
- persist incoming messages and conversations
- ensure EvolutionService logs conversations when sending messages

## Testing
- `python -m py_compile backend/main.py backend/services/evolution.py backend/db/instance_repo.py backend/db/message_repo.py backend/db/conversation_repo.py backend/db/event_repo.py`
- `pytest -q` *(fails: SyntaxError in backend/auth/jwt_auth.py)*

------
https://chatgpt.com/codex/tasks/task_e_68ad7a0a1b708322b42e1d6d2a2c733e