### PR TITLE
Handle QR field mapping for WhatsApp QR codes

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -621,7 +621,7 @@ async def get_qr_code(
         logger.info(f"✅ QR Code obtido para {instance_id}")
         
         return {
-            "qr": result["qr"],
+            "qr_code": result["qr"],
             "status": result.get("status", "QR_AVAILABLE"),
             "expires_at": result.get("expires_at")
         }

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -388,7 +388,11 @@ class WppInstance(BaseModel):
         WhatsAppInstanceStatus.UNKNOWN,
         description="Status atual da conexão"
     )
-    qr_code: Optional[str] = Field(None, description="QR Code em base64 (se disponível)")
+    qr_code: Optional[str] = Field(
+        None,
+        alias="qr",
+        description="QR Code em base64 (se disponível)"
+    )
     phone_number: Optional[str] = Field(None, description="Número conectado")
     profile_name: Optional[str] = Field(None, description="Nome do perfil WhatsApp")
     webhook_url: Optional[str] = Field(None, description="URL do webhook configurado")

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -1386,10 +1386,10 @@ const AgentManager = {
    */
   async getQRCode(instanceName) {
     try {
-      const data = await ApiClient.request(`/api/wpp/instances/${instanceName}/qr`);
+      const { qr } = await ApiClient.request(`/api/wpp/instances/${instanceName}/qr`);
 
-      if (data.qr) {
-        return data.qr;
+      if (qr) {
+        return qr;
       } else {
         throw new Error('QR Code não disponível');
       }


### PR DESCRIPTION
## Summary
- Adjust frontend QR retrieval to use `qr` field from API
- Return `qr_code` field from WhatsApp QR endpoint and map alias in `WppInstance`

## Testing
- `make setup lint test`


------
https://chatgpt.com/codex/tasks/task_e_68ad7eaba2b08322a4a300d572cef54c