### PR TITLE
Validate WhatsApp instance name slug

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -21,6 +21,7 @@ import json
 import asyncio
 import uuid
 import subprocess
+import re
 from contextlib import asynccontextmanager
 from typing import List, Dict, Any, Optional
 from pathlib import Path
@@ -570,7 +571,11 @@ async def create_whatsapp_instance(
         WppInstance: Dados da instância criada
     """
     
-    instance_name = instance_data.get("instance_name", settings.evolution_default_instance)
+    instance_name = (instance_data.get("instance_name") or "").strip()
+    if not instance_name:
+        raise HTTPException(status_code=400, detail="instance_name é obrigatório")
+    if not re.fullmatch(r"[a-z0-9]+(?:-[a-z0-9]+)*", instance_name):
+        raise HTTPException(status_code=400, detail="instance_name deve ser um slug válido")
     logger.info(f"📱 Criando instância WhatsApp: {instance_name}")
     
     try:

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -1300,7 +1300,7 @@ const AgentManager = {
         return;
       }
 
-      const agentSlug = Utils.slugify(agent.agent_name);
+      const instanceName = Utils.slugify(agent.agent_name);
 
       // Abre modal de QR Code
       Modal.open('modal-qr');
@@ -1314,7 +1314,6 @@ const AgentManager = {
       Toast.info('WhatsApp', 'Iniciando conexão com WhatsApp...');
 
       // Cria instância WhatsApp
-      const instanceName = `${appState.evolutionAPI.instanceName}-${agentSlug}`;
       agent.whatsappInstance = instanceName;
       StateManager.persistState();
       await this.createWhatsAppInstance(instanceName);
@@ -1552,8 +1551,7 @@ const AgentManager = {
    * Atualiza status do agente na UI
    */
   updateAgentStatus(instanceName, status) {
-    const slug = instanceName.replace(`${appState.evolutionAPI.instanceName}-`, '');
-    const agent = appState.agents.find(a => Utils.slugify(a.agent_name) === slug);
+    const agent = appState.agents.find(a => Utils.slugify(a.agent_name) === instanceName);
     if (!agent) return;
 
     const card = document.querySelector(`.agent-card[data-agent-id="${agent.id}"]`);


### PR DESCRIPTION
## Summary
- Use agent slug as WhatsApp instance identifier on the frontend
- Validate that `instance_name` is a non-empty slug on the backend

## Testing
- `make setup lint test`


------
https://chatgpt.com/codex/tasks/task_e_68ad8031c87083228d6ec3ab9c8c1da3