### PR TITLE
feat: add webhook inspection endpoint

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -674,6 +674,25 @@ async def get_instance_status(
             detail=f"Erro ao consultar status: {str(e)}"
         )
 
+@app.get("/api/wpp/instances/{instance_id}/webhook")
+async def get_instance_webhook(
+    instance_id: str,
+    evolution_service: EvolutionService = Depends(get_evolution_service),
+):
+    """Consulta a configuração de webhook de uma instância"""
+
+    logger.info(f"🔍 Consultando webhook de {instance_id}")
+
+    try:
+        result = await evolution_service.get_webhook(instance_id)
+        return result
+    except Exception as e:
+        logger.error(f"❌ Erro ao consultar webhook {instance_id}: {str(e)}")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Erro ao consultar webhook: {str(e)}"
+        )
+
 @app.post("/api/wpp/instances/{instance_id}/webhook")
 async def set_instance_webhook(
     instance_id: str,

--- a/backend/services/evolution.py
+++ b/backend/services/evolution.py
@@ -708,7 +708,28 @@ class EvolutionService:
             return "document"
     
     # CONFIGURAÇÃO DE WEBHOOKS
-    
+
+    async def get_webhook(self, instance_name: str) -> Dict[str, Any]:
+        """Obtém configuração de webhook de uma instância"""
+
+        logger.info(f"📥 Consultando webhook de {instance_name}")
+
+        try:
+            result = await self._make_request("GET", f"/webhook/{instance_name}")
+
+            logger.debug(f"🔍 Resposta webhook: {json.dumps(result, indent=2)}")
+
+            webhook_data = result.get("webhook", {})
+            return {
+                "status": result.get("status", "error"),
+                "webhook_url": webhook_data.get("url") or result.get("url"),
+                "events": webhook_data.get("events", [])
+            }
+
+        except EvolutionAPIError as e:
+            logger.error(f"❌ Erro ao consultar webhook {instance_name}: {e.message}")
+            raise
+
     async def set_webhook(self, instance_name: str, webhook_url: str, events: Optional[List[str]] = None) -> bool:
         """
         Configura webhook para receber eventos

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -1453,11 +1453,8 @@ const AgentManager = {
                 Toast.warning('WhatsApp', 'Não foi possível confirmar o status da conexão.');
               }
 
-              let webhookOk = false;
-              if (webhookCheck.ok) {
-                const webhookData = await webhookCheck.json().catch(() => ({}));
-                webhookOk = webhookData.status === 'success';
-              }
+              const webhookData = await webhookCheck.json().catch(() => ({}));
+              const webhookOk = webhookCheck.ok && webhookData.status === 'success';
               if (!webhookOk) {
                 Logger.log('warning', 'whatsapp', JSON.stringify({ action: 'verify_webhook', success: false, httpStatus: webhookCheck.status }));
                 Toast.warning('WhatsApp', 'Webhook não confirmado.');


### PR DESCRIPTION
## Summary
- add endpoint to inspect webhook configuration
- query Evolution API for webhook details
- verify webhook setup from the frontend and treat non-success as failure

## Testing
- `make setup`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68ad8149cf2c832293feb3bdc4dd5c15