### PR TITLE
feat: support custom webhook events

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -558,28 +558,36 @@ async def materialize_agent(
 
 @app.post("/api/wpp/instances", response_model=InstanceState)
 async def create_whatsapp_instance(
-    instance_data: Dict[str, str],
+    instance_data: Dict[str, Any],
     evolution_service: EvolutionService = Depends(get_evolution_service)
 ):
     """
     Cria ou recupera uma instância do WhatsApp via Evolution API
-    
+
     Args:
         instance_data: Dados da instância (ex: {"instance_name": "my-agent"})
-        
+
     Returns:
         InstanceState: Estado da instância criada
     """
-    
+
     instance_name = (instance_data.get("instance_name") or "").strip()
     if not instance_name:
         raise HTTPException(status_code=400, detail="instance_name é obrigatório")
     if not re.fullmatch(r"[a-z0-9]+(?:-[a-z0-9]+)*", instance_name):
         raise HTTPException(status_code=400, detail="instance_name deve ser um slug válido")
+
+    webhook_url = instance_data.get("webhook_url")
+    events = instance_data.get("events")
+
     logger.info(f"📱 Criando instância WhatsApp: {instance_name}")
-    
+
     try:
-        result = await evolution_service.create_instance(instance_name)
+        result = await evolution_service.create_instance(
+            instance_name,
+            webhook_url=webhook_url,
+            events=events,
+        )
 
         logger.info(f"✅ Instância {instance_name} criada/recuperada")
 

--- a/backend/services/evolution.py
+++ b/backend/services/evolution.py
@@ -224,26 +224,33 @@ class EvolutionService:
     
     # OPERAÇÕES DE INSTÂNCIA
     
-    async def create_instance(self, instance_name: str, webhook_url: Optional[str] = None) -> Dict[str, Any]:
+    async def create_instance(
+        self,
+        instance_name: str,
+        webhook_url: Optional[str] = None,
+        events: Optional[List[str]] = None,
+    ) -> Dict[str, Any]:
         """
         Cria ou recupera uma instância do WhatsApp
-        
+
         Args:
             instance_name: Nome único da instância
             webhook_url: URL para receber webhooks (opcional)
-            
+            events: Lista de eventos a serem assinados (opcional)
+
         Returns:
             Dict com dados da instância criada
         """
-        
+
         logger.info(f"📱 Criando instância: {instance_name}")
-        
+
         try:
             # Dados para criação da instância
             payload = {
                 "instanceName": instance_name,
                 "integration": "WHATSAPP-BAILEYS",
-                "webhook_url": webhook_url
+                "webhook_url": webhook_url,
+                "events": events,
             }
 
             # Remove campos None
@@ -269,7 +276,8 @@ class EvolutionService:
                 "instance_id": instance_name,
                 "status": "created",
                 "webhook_url": webhook_url,
-                "api_response": response
+                "events": events,
+                "api_response": response,
             }
 
         except EvolutionAPIError as e:
@@ -287,6 +295,7 @@ class EvolutionService:
                         "instance_id": instance_name,
                         "status": status_info.get("state", "unknown"),
                         "webhook_url": webhook_url,
+                        "events": events,
                         "api_response": status_info,
                     }
                 except EvolutionAPIError as status_error:
@@ -317,6 +326,7 @@ class EvolutionService:
                             "instance_id": instance_name,
                             "status": "recreated",
                             "webhook_url": webhook_url,
+                            "events": events,
                             "api_response": response,
                         }
                     except EvolutionAPIError as recreate_error:


### PR DESCRIPTION
## Summary
- allow POST `/api/wpp/instances` to accept `webhook_url` and `events`
- pass new params through to Evolution API when creating instances

## Testing
- `make setup`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68ad87c10f188322b0dd5668c8b9931f