### PR TITLE
feat: verify database configuration before migrations

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,6 +11,12 @@ These instructions apply to the entire repository.
 - Shell scripts must be POSIX compatible and start with `#!/bin/sh` and `set -e`.
 - Keep Makefile targets simple and cross-platform.
 
+## Environment Configuration
+- Configure a `.env` file with the required settings.
+- Define `DB_PROVIDER` (e.g., `sqlite` or `postgres`).
+- Define `DATABASE_URL`; this is mandatory when `DB_PROVIDER=postgres`.
+- Ensure the `.env` file is not committed and has restricted permissions (e.g., `chmod 600 .env`).
+
 ## Do not
 - Do not modify files inside `node_modules/` or generated artifacts.
 - Do not store secrets in the repository.

--- a/backend/main.py
+++ b/backend/main.py
@@ -205,6 +205,19 @@ async def lifespan(app: FastAPI):
     settings.generated_agents_dir.mkdir(exist_ok=True)
     logger.info(f"Diretório de agentes criado: {settings.generated_agents_dir}")
 
+    # Verifica configurações de banco de dados antes das migrações
+    db_provider = os.getenv("DB_PROVIDER", "sqlite")
+    database_url = os.getenv("DATABASE_URL")
+    logger.info(f"DB_PROVIDER: {db_provider}")
+    if database_url:
+        logger.info(f"DATABASE_URL: {database_url}")
+    else:
+        logger.warning("DATABASE_URL não definido")
+
+    if db_provider == "postgres" and not database_url:
+        logger.error("DATABASE_URL é obrigatório quando DB_PROVIDER=postgres")
+        raise RuntimeError("DATABASE_URL environment variable is required for Postgres")
+
     # Executa migrações do banco de dados
     try:
         subprocess.run(


### PR DESCRIPTION
## Summary
- log DB_PROVIDER and DATABASE_URL before running migrations
- fail fast if DB_PROVIDER=postgres without DATABASE_URL
- document .env database configuration and permissions

## Testing
- ⚠️ `make setup` (failed: Could not find a version that satisfies the requirement agno==0.0.39)
- ✅ `make lint`
- ✅ `make test`


------
https://chatgpt.com/codex/tasks/task_e_68ad9357819c8322aef779498f26b0a5