### PR TITLE
Add agent repository and API tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,72 @@
+import pytest
+import subprocess
+
+
+@pytest.fixture(autouse=True)
+def mock_database(monkeypatch):
+    agents = {}
+    next_id = 1
+
+    async def run_query(action, payload=None):
+        nonlocal next_id
+        payload = payload or {}
+        if action in ("init", "init_events"):
+            return None
+        if action == "list":
+            return list(agents.values())
+        if action == "get":
+            return agents.get(int(payload["id"]))
+        if action == "get_by_name":
+            name = payload.get("name")
+            for row in agents.values():
+                if row["name"] == name:
+                    return row
+            return None
+        if action == "create":
+            name = payload.get("name")
+            if not name:
+                raise RuntimeError("validation error")
+            for row in agents.values():
+                if row["name"] == name:
+                    raise RuntimeError("UNIQUE constraint failed")
+            row = {
+                "id": next_id,
+                "name": name,
+                "specialization": payload.get("specialization", ""),
+                "instructions": payload.get("instructions", ""),
+                "status": "draft",
+                "createdAt": 0,
+                "updatedAt": 0,
+            }
+            agents[next_id] = row
+            next_id += 1
+            return row
+        if action == "log_event":
+            return {"ok": True}
+        return None
+
+    monkeypatch.setattr("backend.db.agent_repository.run_query", run_query)
+    monkeypatch.setattr("backend.db.event_repo.run_query", run_query)
+
+    def fake_run(*args, **kwargs):
+        return subprocess.CompletedProcess(args, 0)
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    try:
+        from backend.services.evolution import EvolutionService
+
+        async def fake_test_connection(self):
+            return None
+
+        monkeypatch.setattr(
+            EvolutionService,
+            "test_connection",
+            fake_test_connection,
+        )
+    except ModuleNotFoundError:
+        pass
+
+    yield
+    agents.clear()
+    next_id = 1

--- a/tests/integration/test_agents_api.py
+++ b/tests/integration/test_agents_api.py
@@ -1,0 +1,158 @@
+import os
+import sys
+
+import pytest
+from fastapi.testclient import TestClient
+
+ROOT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, ROOT_DIR)
+
+import backend.models as backend_models
+sys.modules["models"] = backend_models
+
+import backend.db as backend_db
+import backend.db.agent_repository as backend_ar
+sys.modules["db"] = backend_db
+sys.modules["db.agent_repository"] = backend_ar
+
+import types
+
+schemas_module = types.ModuleType("schemas")
+sys.modules["schemas"] = schemas_module
+
+from pydantic import BaseModel
+from typing import List, Optional, Dict, Any
+
+
+class AgentCreate(BaseModel):
+    agent_name: str
+    instructions: str
+    specialization: str
+    tools: List[str]
+    integrations: Optional[Dict[str, Any]] = None
+
+
+class AgentInfo(BaseModel):
+    id: str
+    name: str
+    specialization: str
+    instructions: str
+    tools: List[str]
+    status: str = "draft"
+    config: Dict[str, Any] = {}
+
+
+class AgentUpdate(BaseModel):
+    pass
+
+
+class AgentGeneratedFiles(BaseModel):
+    pass
+
+
+class InstanceState(BaseModel):
+    pass
+
+
+class SendMessage(BaseModel):
+    pass
+
+
+class HealthResponse(BaseModel):
+    pass
+
+
+class LogEntry(BaseModel):
+    pass
+
+
+class MaterializeRequest(BaseModel):
+    pass
+
+
+class StatusResponse(BaseModel):
+    pass
+
+
+class ServiceChecks(BaseModel):
+    pass
+
+
+schemas_module.AgentCreate = AgentCreate
+schemas_module.AgentGeneratedFiles = AgentGeneratedFiles
+schemas_module.InstanceState = InstanceState
+schemas_module.SendMessage = SendMessage
+schemas_module.HealthResponse = HealthResponse
+schemas_module.LogEntry = LogEntry
+schemas_module.MaterializeRequest = MaterializeRequest
+schemas_module.AgentInfo = AgentInfo
+schemas_module.AgentUpdate = AgentUpdate
+schemas_module.StatusResponse = StatusResponse
+schemas_module.ServiceChecks = ServiceChecks
+
+services_module = types.ModuleType("services")
+
+class DummyGenerator:
+    def __init__(self, *args, **kwargs):
+        pass
+
+class DummyEvolution:
+    def __init__(self, *args, **kwargs):
+        pass
+
+    async def test_connection(self):
+        return None
+
+class DummyAgno:
+    def __init__(self, *args, **kwargs):
+        pass
+
+generator_mod = types.ModuleType("generator")
+generator_mod.CodeGeneratorService = DummyGenerator
+
+evolution_mod = types.ModuleType("evolution")
+evolution_mod.EvolutionService = DummyEvolution
+
+agno_mod = types.ModuleType("agno")
+agno_mod.AgnoService = DummyAgno
+
+services_module.generator = generator_mod
+services_module.evolution = evolution_mod
+services_module.agno = agno_mod
+
+sys.modules["services"] = services_module
+sys.modules["services.generator"] = generator_mod
+sys.modules["services.evolution"] = evolution_mod
+sys.modules["services.agno"] = agno_mod
+
+import backend.context as backend_context
+sys.modules["context"] = backend_context
+
+from backend.main import app, get_current_user
+
+
+@pytest.fixture
+def client():
+    app.dependency_overrides[get_current_user] = lambda: {"user": "test"}
+    with TestClient(app) as c:
+        yield c
+    app.dependency_overrides.clear()
+
+
+def test_create_agent_endpoint_idempotent(client):
+    payload = {
+        "agent_name": "agent1",
+        "instructions": "i" * 80,
+        "specialization": "Atendimento",
+        "tools": ["calendar"],
+    }
+    resp1 = client.post("/api/agents", json=payload)
+    assert resp1.status_code == 201
+    data1 = resp1.json()
+    assert data1["name"] == payload["agent_name"]
+    assert data1["tools"] == ["calendar"]
+
+    resp2 = client.post("/api/agents", json=payload)
+    assert resp2.status_code == 201
+    data2 = resp2.json()
+    assert data2["id"] == data1["id"]

--- a/tests/unit/test_agents.py
+++ b/tests/unit/test_agents.py
@@ -1,0 +1,60 @@
+import os
+import sys
+
+import pytest
+
+ROOT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, ROOT_DIR)
+
+import backend.models as backend_models
+sys.modules["models"] = backend_models
+
+from backend.db.agent_repository import AgentRepository
+
+
+@pytest.mark.asyncio
+async def test_create_agent_success():
+    repo = AgentRepository()
+    data = {
+        "name": "agent1",
+        "specialization": "spec",
+        "instructions": "i" * 80,
+        "tools": ["t1"],
+        "config": {"a": 1},
+    }
+    agent = await repo.create_agent(data)
+    assert agent.id == "1"
+    assert agent.name == "agent1"
+    assert agent.tools == ["t1"]
+    assert agent.config == {"a": 1}
+
+
+@pytest.mark.asyncio
+async def test_create_agent_duplicate_returns_existing():
+    repo = AgentRepository()
+    data = {
+        "name": "agent1",
+        "specialization": "spec",
+        "instructions": "i" * 80,
+        "tools": ["t1"],
+        "config": {"a": 1},
+    }
+    first = await repo.create_agent(data)
+    data["tools"] = ["t2"]
+    data["config"] = {"b": 2}
+    second = await repo.create_agent(data)
+    assert second.id == first.id
+    assert second.tools == ["t2"]
+    assert second.config == {"b": 2}
+
+
+@pytest.mark.asyncio
+async def test_create_agent_validation_error():
+    repo = AgentRepository()
+    data = {
+        "specialization": "spec",
+        "instructions": "i" * 80,
+        "tools": ["t1"],
+    }
+    with pytest.raises(RuntimeError):
+        await repo.create_agent(data)


### PR DESCRIPTION
## Summary
- add unit tests for AgentRepository.create_agent covering success, duplicates and validation errors
- add integration test for POST /api/agents ensuring idempotent behavior and response structure
- provide shared fixtures to mock database and cleanup per test

## Testing
- `make setup` (fails: No matching distribution found for agno==0.0.39)
- `make lint`
- `make test`
- `pytest tests/unit tests/integration -q`


------
https://chatgpt.com/codex/tasks/task_e_68adc05a9f3c832282aa18742487743f