### PR TITLE
feat: add Playwright e2e tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,22 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - run: make setup
+      - run: make lint
+      - run: make test
+      - run: make e2e

--- a/Makefile
+++ b/Makefile
@@ -13,4 +13,4 @@ dev:
 	sh scripts/start.sh
 
 e2e:
-	echo "e2e tests ok"
+	npx playwright test

--- a/README.md
+++ b/README.md
@@ -507,6 +507,19 @@ flake8 backend/
 mypy backend/
 ```
 
+### Testes End-to-End
+
+Checklist de telas cobertas:
+
+- [x] Criação de agente
+- [x] Consulta RAG
+
+```bash
+make e2e
+```
+
+Os testes E2E também são executados no CI.
+
 ---
 
 ## 📚 Documentação Adicional

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "pg": "^8.11.3"
       },
       "devDependencies": {
+        "@playwright/test": "^1.55.0",
         "drizzle-kit": "^0.31.4",
         "tsx": "^4.7.0"
       }
@@ -904,6 +905,22 @@
         "node": ">=18"
       }
     },
+    "node_modules/@playwright/test": {
+      "version": "1.55.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.55.0.tgz",
+      "integrity": "sha512-04IXzPwHrW69XusN/SIdDdKZBzMfOT9UNT/YiJit/xpy2VuAoB8NHc8Aplb96zsWDddLnbkPL3TsmrS04ZU2xQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.55.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/base64-js": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
@@ -1498,6 +1515,53 @@
       "license": "MIT",
       "dependencies": {
         "split2": "^4.1.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.55.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.55.0.tgz",
+      "integrity": "sha512-sdCWStblvV1YU909Xqx0DhOjPZE4/5lJsIS84IfN9dAZfcl/CIZ5O8l3o0j7hPMjDvqoTF8ZUcc+i/GL5erstA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.55.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.55.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.55.0.tgz",
+      "integrity": "sha512-GvZs4vU3U5ro2nZpeiwyb0zuFaqb9sUiAJuyrWpcGouD8y9/HLgGbNRjIph7zU9D3hnPaisMl9zG9CgFi/biIg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/postgres-array": {

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "pg": "^8.11.3"
   },
   "devDependencies": {
+    "@playwright/test": "^1.55.0",
     "drizzle-kit": "^0.31.4",
     "tsx": "^4.7.0"
   }

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './tests/e2e',
+  use: {
+    baseURL: 'http://localhost:8000',
+    headless: true,
+  },
+});

--- a/scripts/codex_setup.sh
+++ b/scripts/codex_setup.sh
@@ -6,4 +6,5 @@ echo "Running project setup"
 # Install project dependencies
 npm install
 pip install -r backend/requirements.txt
+npx playwright install
 

--- a/tests/e2e/agent_creation.spec.ts
+++ b/tests/e2e/agent_creation.spec.ts
@@ -1,0 +1,23 @@
+import { test, expect } from './fixtures';
+
+// Creates a new agent through the UI and verifies it persists in the agent list
+
+const LONG_INSTRUCTIONS = 'Instruções '.repeat(10); // >80 chars
+
+test('criar agente e verificar persistência', async ({ page }) => {
+  await page.goto('/');
+
+  await page.fill('#agent_name', 'Agente Teste');
+  await page.fill('#instructions', LONG_INSTRUCTIONS);
+  await page.selectOption('#specialization', { value: 'Suporte' });
+
+  await page.click('#btn-continue');
+
+  await page.waitForSelector('#btn-materialize-server:not([disabled])');
+  await page.click('#btn-materialize-server');
+
+  await page.click('button.tab-button[data-section="page-agents"]');
+
+  const card = page.locator('#agents-grid').locator('text=Agente Teste');
+  await expect(card).toBeVisible();
+});

--- a/tests/e2e/fixtures.ts
+++ b/tests/e2e/fixtures.ts
@@ -1,0 +1,5 @@
+import { test as base } from '@playwright/test';
+
+// Extend base fixtures here if needed
+export const test = base;
+export const expect = test.expect;

--- a/tests/e2e/rag_call.spec.ts
+++ b/tests/e2e/rag_call.spec.ts
@@ -1,0 +1,13 @@
+import { test, expect } from './fixtures';
+
+// Executes a RAG query via API and validates the response structure
+
+test('executa consulta RAG e valida resposta', async ({ request }) => {
+  const response = await request.post('/api/rag', {
+    data: { query: 'Olá, tudo bem?' }
+  });
+
+  expect(response.ok()).toBeTruthy();
+  const json = await response.json();
+  expect(json).toHaveProperty('answer');
+});


### PR DESCRIPTION
## Summary
- set up Playwright with config and fixtures
- add agent creation and RAG call e2e tests
- wire e2e tests into Makefile, CI, and docs

## Testing
- `make setup` *(fails: No matching distribution found for schemathesis==3.21.6)*
- `make lint`
- `make test`
- `make e2e` *(fails: connect ECONNREFUSED ::1:8000)*

------
https://chatgpt.com/codex/tasks/task_e_68add25a38fc8322b239eee2803f4c0b