### PR TITLE
feat(frontend): modernize UI design

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -4,7 +4,11 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Gerador de Agentes SDK com integração ao WhatsApp via Evolution API">
+    <meta name="theme-color" content="#3b82f6">
     <title>Agno SDK Agent Generator</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="styles.css">
 </head>
 <body>

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -1,34 +1,34 @@
-/* Design Tokens - iOS Dark Theme */
+/* Design Tokens - Light Theme */
 :root {
   /* Colors */
-  --bg: #0B0B0F;
-  --surface: #1C1C1E;
-  --surface-alt: #2C2C2E;
-  --stroke: #3A3A3C;
-  --text-primary: #F2F2F7;
-  --text-secondary: #C7C7CC;
-  --accent: #0A84FF;
-  --success: #32D74B;
-  --warning: #FFD60A;
-  --danger: #FF453A;
-  
+  --bg: #f8fafc;
+  --surface: #ffffff;
+  --surface-alt: #f1f5f9;
+  --stroke: #e2e8f0;
+  --text-primary: #1e293b;
+  --text-secondary: #475569;
+  --accent: #3b82f6;
+  --success: #16a34a;
+  --warning: #facc15;
+  --danger: #ef4444;
+
   /* Layout */
   --radius: 20px;
   --radius-small: 12px;
-  --shadow: 0 6px 24px rgba(0,0,0,.35);
-  --shadow-small: 0 2px 12px rgba(0,0,0,.25);
+  --shadow: 0 6px 24px rgba(0, 0, 0, 0.08);
+  --shadow-small: 0 2px 12px rgba(0, 0, 0, 0.04);
   --transition: 180ms ease;
   --transition-fast: 150ms ease;
   --transition-slow: 220ms ease;
-  
+
   /* Typography */
-  --font-family: system-ui, -apple-system, 'SF Pro Text', 'SF Pro Display', Inter, Roboto, Arial, sans-serif;
+  --font-family: 'Inter', system-ui, -apple-system, 'SF Pro Text', 'SF Pro Display', Roboto, Arial, sans-serif;
   --font-size-h1: 28px;
   --font-size-h2: 22px;
   --font-size-h3: 18px;
-  --font-size-body: 15px;
-  --font-size-caption: 13px;
-  
+  --font-size-body: 16px;
+  --font-size-caption: 14px;
+
   /* Spacing */
   --space-xs: 4px;
   --space-sm: 8px;
@@ -36,7 +36,7 @@
   --space-lg: 16px;
   --space-xl: 24px;
   --space-xxl: 32px;
-  
+
   /* Z-index */
   --z-modal: 1000;
   --z-toast: 1100;
@@ -48,16 +48,16 @@
   --font-size-h1: 24px;
   --font-size-h2: 20px;
   --font-size-h3: 16px;
-  --font-size-body: 13px;
-  --font-size-caption: 11px;
+  --font-size-body: 14px;
+  --font-size-caption: 12px;
 }
 
 :root[data-font-scale="1"] {
   --font-size-h1: 32px;
   --font-size-h2: 26px;
   --font-size-h3: 20px;
-  --font-size-body: 17px;
-  --font-size-caption: 15px;
+  --font-size-body: 18px;
+  --font-size-caption: 16px;
 }
 
 /* Reduced Motion Support */
@@ -263,6 +263,9 @@ body {
   display: flex;
   flex-direction: column;
   gap: var(--space-xl);
+  max-width: 800px;
+  margin: 0 auto;
+  padding: 0 var(--space-xl);
 }
 
 /* Section Cards */
@@ -1570,7 +1573,18 @@ body {
   }
 }
 
-/* Dark Mode Support (if system preference changes) */
-@media (prefers-color-scheme: light) {
-  /* We maintain dark theme regardless of system preference per specification */
+/* Dark Mode Support */
+@media (prefers-color-scheme: dark) {
+  :root {
+    --bg: #0B0B0F;
+    --surface: #1C1C1E;
+    --surface-alt: #2C2C2E;
+    --stroke: #3A3A3C;
+    --text-primary: #F2F2F7;
+    --text-secondary: #C7C7CC;
+    --accent: #0A84FF;
+    --success: #32D74B;
+    --warning: #FFD60A;
+    --danger: #FF453A;
+  }
 }


### PR DESCRIPTION
## Summary
- refresh frontend with light theme color palette and dark mode support
- load Inter font from Google Fonts and add theme color meta for better branding
- refine section layout for improved readability and responsiveness

## Testing
- `make setup` *(fails: Could not find a version that satisfies the requirement schemathesis==3.21.6)*
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68ade2b353e4832283088c8526c1c9a7